### PR TITLE
Replace GoogleMap getMap with getMapAsync

### DIFF
--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/googlemaps/MapsActivity.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/googlemaps/MapsActivity.java
@@ -6,6 +6,7 @@ import android.text.TextUtils;
 
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import com.google.android.gms.maps.model.LatLng;
@@ -21,7 +22,7 @@ import com.indooratlas.android.sdk.examples.SdkExample;
 import com.indooratlas.android.sdk.examples.utils.ExampleUtils;
 
 @SdkExample(description = R.string.example_googlemaps_basic_description)
-public class MapsActivity extends FragmentActivity implements IALocationListener {
+public class MapsActivity extends FragmentActivity implements IALocationListener, OnMapReadyCallback {
 
     private static final float HUE_IABLUE = 200.0f;
 
@@ -42,6 +43,11 @@ public class MapsActivity extends FragmentActivity implements IALocationListener
             final IALocation FLOOR_PLAN_ID = IALocation.from(IARegion.floorPlan(floorPlanId));
             mIALocationManager.setLocation(FLOOR_PLAN_ID);
         }
+
+        // Try to obtain the map from the SupportMapFragment.
+        ((SupportMapFragment) getSupportFragmentManager()
+                .findFragmentById(R.id.map))
+                .getMapAsync(this);
     }
 
     @Override
@@ -53,19 +59,7 @@ public class MapsActivity extends FragmentActivity implements IALocationListener
     @Override
     protected void onResume() {
         super.onResume();
-        if (mMap == null) {
-            mMap = ((SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map))
-                    .getMap();
-        }
         mIALocationManager.requestLocationUpdates(IALocationRequest.create(), this);
-
-        mMap.setOnMapLongClickListener(new GoogleMap.OnMapLongClickListener() {
-            @Override
-            public void onMapLongClick(LatLng latLng) {
-                ExampleUtils.shareText(MapsActivity.this, mIALocationManager.getExtraInfo().traceId,
-                        "traceId");
-            }
-        });
     }
 
     @Override
@@ -75,6 +69,18 @@ public class MapsActivity extends FragmentActivity implements IALocationListener
             mIALocationManager.removeLocationUpdates(this);
         }
 
+    }
+
+    @Override
+    public void onMapReady(GoogleMap googleMap) {
+        mMap = googleMap;
+        mMap.setOnMapLongClickListener(new GoogleMap.OnMapLongClickListener() {
+            @Override
+            public void onMapLongClick(LatLng latLng) {
+                ExampleUtils.shareText(MapsActivity.this, mIALocationManager.getExtraInfo().traceId,
+                        "traceId");
+            }
+        });
     }
 
     /**

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/googlemapsindoor/GoogleMapsIndoorActivity.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/googlemapsindoor/GoogleMapsIndoorActivity.java
@@ -5,6 +5,7 @@ import android.support.v4.app.FragmentActivity;
 
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import com.google.android.gms.maps.model.Circle;
@@ -27,7 +28,7 @@ import java.util.Map;
 
 @SdkExample(description = R.string.example_googlemaps_indoor_description)
 public class GoogleMapsIndoorActivity extends FragmentActivity implements
-        IALocationListener, GoogleMap.OnIndoorStateChangeListener {
+        IALocationListener, GoogleMap.OnIndoorStateChangeListener, OnMapReadyCallback {
 
     private GoogleMap mMap; // Might be null if Google Play services APK is not available.
     private Circle mCircle;
@@ -155,6 +156,11 @@ public class GoogleMapsIndoorActivity extends FragmentActivity implements
         setContentView(R.layout.activity_maps);
         mIALocationManager = IALocationManager.create(this);
         mFloorLevelMatcher = new GoogleMapsFloorLevelMatcher();
+
+        // Try to obtain the map from the SupportMapFragment.
+        ((SupportMapFragment) getSupportFragmentManager()
+                .findFragmentById(R.id.map))
+                .getMapAsync(this);
     }
 
     @Override
@@ -166,12 +172,10 @@ public class GoogleMapsIndoorActivity extends FragmentActivity implements
     @Override
     protected void onResume() {
         super.onResume();
-        if (mMap == null) {
-            mMap = ((SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map))
-                    .getMap();
+        mIALocationManager.requestLocationUpdates(IALocationRequest.create(), this);
+        if (mMap != null) {
             mMap.setOnIndoorStateChangeListener(this);
         }
-        mIALocationManager.requestLocationUpdates(IALocationRequest.create(), this);
     }
 
     @Override
@@ -183,6 +187,12 @@ public class GoogleMapsIndoorActivity extends FragmentActivity implements
         if (mMap != null) {
             mMap.setOnIndoorStateChangeListener(null);
         }
+    }
+
+    @Override
+    public void onMapReady(GoogleMap googleMap) {
+        mMap = googleMap;
+        mMap.setOnIndoorStateChangeListener(this);
     }
 
     @Override

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/mapsoverlay/MapsOverlayActivity.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/mapsoverlay/MapsOverlayActivity.java
@@ -16,6 +16,7 @@ import android.content.Context;
 
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
@@ -46,7 +47,7 @@ import com.squareup.picasso.RequestCreator;
 import com.squareup.picasso.Target;
 
 @SdkExample(description = R.string.example_googlemaps_overlay_description)
-public class MapsOverlayActivity extends FragmentActivity implements LocationListener {
+public class MapsOverlayActivity extends FragmentActivity implements LocationListener, OnMapReadyCallback {
 
     private static final String TAG = "IndoorAtlasExample";
 
@@ -209,6 +210,11 @@ public class MapsOverlayActivity extends FragmentActivity implements LocationLis
         mResourceManager = IAResourceManager.create(this);
 
         startListeningPlatformLocations();
+
+        // Try to obtain the map from the SupportMapFragment.
+        ((SupportMapFragment) getSupportFragmentManager()
+                .findFragmentById(R.id.map))
+                .getMapAsync(this);
     }
 
     @Override
@@ -221,25 +227,10 @@ public class MapsOverlayActivity extends FragmentActivity implements LocationLis
     @Override
     protected void onResume() {
         super.onResume();
-        if (mMap == null) {
-            // Try to obtain the map from the SupportMapFragment.
-            mMap = ((SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map))
-                    .getMap();
-            mMap.setMyLocationEnabled(false);
-        }
 
         // start receiving location updates & monitor region changes
         mIALocationManager.requestLocationUpdates(IALocationRequest.create(), mListener);
         mIALocationManager.registerRegionListener(mRegionListener);
-
-        // Setup long click to share the traceId
-        mMap.setOnMapLongClickListener(new GoogleMap.OnMapLongClickListener() {
-            @Override
-            public void onMapLongClick(LatLng latLng) {
-                ExampleUtils.shareText(MapsOverlayActivity.this,
-                        mIALocationManager.getExtraInfo().traceId, "traceId");
-            }
-        });
     }
 
     @Override
@@ -250,6 +241,21 @@ public class MapsOverlayActivity extends FragmentActivity implements LocationLis
         mIALocationManager.registerRegionListener(mRegionListener);
     }
 
+    @Override
+    public void onMapReady(GoogleMap googleMap) {
+        mMap = googleMap;
+        // do not show Google's outdoor location
+        mMap.setMyLocationEnabled(false);
+
+        // Setup long click to share the traceId
+        mMap.setOnMapLongClickListener(new GoogleMap.OnMapLongClickListener() {
+            @Override
+            public void onMapLongClick(LatLng latLng) {
+                ExampleUtils.shareText(MapsOverlayActivity.this,
+                        mIALocationManager.getExtraInfo().traceId, "traceId");
+            }
+        });
+    }
 
     /**
      * Sets bitmap of floor plan as ground overlay on Google Maps

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/wayfinding/WayfindingOverlayActivity.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/wayfinding/WayfindingOverlayActivity.java
@@ -21,6 +21,7 @@ import android.widget.Toast;
 
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
@@ -65,7 +66,7 @@ import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 
 @SdkExample(description = R.string.example_wayfinding_description)
 public class WayfindingOverlayActivity extends FragmentActivity implements LocationListener,
-        GoogleMap.OnMapClickListener {
+        GoogleMap.OnMapClickListener, OnMapReadyCallback {
     private static final int MY_PERMISSION_ACCESS_FINE_LOCATION = 42;
 
     private static final String TAG = "IndoorAtlasExample";
@@ -265,6 +266,10 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Locat
             mWayfinder = IAWayfinder.create(this, graphJSON);
         }
 
+        // Try to obtain the map from the SupportMapFragment.
+        ((SupportMapFragment) getSupportFragmentManager()
+                .findFragmentById(R.id.map))
+                .getMapAsync(this);
     }
 
     @Override
@@ -280,18 +285,10 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Locat
     @Override
     protected void onResume() {
         super.onResume();
-        if (mMap == null) {
-            // Try to obtain the map from the SupportMapFragment.
-            mMap = ((SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map))
-                    .getMap();
-            mMap.setMyLocationEnabled(false);
-        }
 
         // start receiving location updates & monitor region changes
         mIALocationManager.requestLocationUpdates(IALocationRequest.create(), mListener);
         mIALocationManager.registerRegionListener(mRegionListener);
-
-        mMap.setOnMapClickListener(this);
     }
 
     @Override
@@ -302,6 +299,12 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Locat
         mIALocationManager.registerRegionListener(mRegionListener);
     }
 
+    @Override
+    public void onMapReady(GoogleMap googleMap) {
+        mMap = googleMap;
+        mMap.setMyLocationEnabled(false);
+        mMap.setOnMapClickListener(this);
+    }
 
     /**
      * Sets bitmap of floor plan as ground overlay on Google Maps


### PR DESCRIPTION
The synchronous method `getMap` for obtaining a `GoogleMap` instance has been deprecated in favor of `getMapAsync`.