### PR TITLE
Update examples to SDK 2.9

### DIFF
--- a/Basic/build.gradle
+++ b/Basic/build.gradle
@@ -50,7 +50,7 @@ android {
 }
 
 dependencies {
-    compile "com.indooratlas.android:indooratlas-android-sdk:2.9.0@aar"
+    compile "com.indooratlas.android:indooratlas-android-sdk:2.9.0-beta-931@aar"
 
     compile 'com.android.support:appcompat-v7:26.1.0'
     compile 'com.google.android.gms:play-services-maps:8.1.0'

--- a/Basic/build.gradle
+++ b/Basic/build.gradle
@@ -50,7 +50,7 @@ android {
 }
 
 dependencies {
-    compile "com.indooratlas.android:indooratlas-android-sdk:2.8.3@aar"
+    compile "com.indooratlas.android:indooratlas-android-sdk:2.9.0@aar"
     compile 'com.indooratlas.android:indooratlas-android-wayfinding:2.8.0'
 
     compile 'com.android.support:appcompat-v7:26.1.0'

--- a/Basic/build.gradle
+++ b/Basic/build.gradle
@@ -51,7 +51,6 @@ android {
 
 dependencies {
     compile "com.indooratlas.android:indooratlas-android-sdk:2.9.0@aar"
-    compile 'com.indooratlas.android:indooratlas-android-wayfinding:2.8.0'
 
     compile 'com.android.support:appcompat-v7:26.1.0'
     compile 'com.google.android.gms:play-services-maps:8.1.0'

--- a/Basic/src/main/AndroidManifest.xml
+++ b/Basic/src/main/AndroidManifest.xml
@@ -105,6 +105,11 @@
             android:label="@string/example_foregroundservice_title"
             android:screenOrientation="portrait" />
 
+        <activity
+            android:name=".lockfloor.LockFloorActivity"
+            android:label="@string/example_lockfloor_title"
+            android:screenOrientation="portrait" />
+
         <service
             android:name=".foregroundservice.ForegroundService"
             android:exported="false" />

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/lockfloor/LockFloorActivity.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/lockfloor/LockFloorActivity.java
@@ -1,0 +1,269 @@
+package com.indooratlas.android.sdk.examples.lockfloor;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.SystemClock;
+import android.support.v7.app.AppCompatActivity;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.NumberPicker;
+import android.widget.ScrollView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.indooratlas.android.sdk.IALocation;
+import com.indooratlas.android.sdk.IALocationListener;
+import com.indooratlas.android.sdk.IALocationManager;
+import com.indooratlas.android.sdk.IALocationRequest;
+import com.indooratlas.android.sdk.IARegion;
+import com.indooratlas.android.sdk.examples.R;
+import com.indooratlas.android.sdk.examples.SdkExample;
+import com.indooratlas.android.sdk.examples.utils.ExampleUtils;
+
+import java.util.Locale;
+
+/**
+ * Simple example that demonstrates basic interaction with {@link IALocationManager}.
+ */
+@SdkExample(description = R.string.example_lockfloor_description)
+public class LockFloorActivity extends AppCompatActivity
+        implements IALocationListener, IARegion.Listener {
+
+    static final String FASTEST_INTERVAL = "fastestInterval";
+    static final String SHORTEST_DISPLACEMENT = "shortestDisplacement";
+
+    private IALocationManager mLocationManager;
+    private TextView mLog;
+    private ScrollView mScrollView;
+    private long mRequestStartTime;
+
+    private long mFastestInterval = -1L;
+    private float mShortestDisplacement = -1f;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (savedInstanceState != null) {
+            mFastestInterval = savedInstanceState.getLong(FASTEST_INTERVAL);
+            mShortestDisplacement = savedInstanceState.getFloat(SHORTEST_DISPLACEMENT);
+        }
+
+        setContentView(R.layout.activity_lockfloor);
+        mLog = (TextView) findViewById(R.id.text);
+        mScrollView = (ScrollView) findViewById(R.id.scroller);
+        mLocationManager = IALocationManager.create(this);
+
+        // Register long click for sharing traceId
+        ExampleUtils.shareTraceId(mLog, LockFloorActivity.this, mLocationManager);
+
+        mRequestStartTime = SystemClock.elapsedRealtime();
+        IALocationRequest request = IALocationRequest.create();
+
+        mLocationManager.requestLocationUpdates(request, LockFloorActivity.this);
+
+        log("requestLocationUpdates");
+
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        mLocationManager.destroy();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        mLocationManager.registerRegionListener(this);
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        mLocationManager.unregisterRegionListener(this);
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.menu_simple, menu);
+        return super.onCreateOptionsMenu(menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        final int id = item.getItemId();
+        switch (id) {
+            case R.id.action_clear:
+                mLog.setText(null);
+                return true;
+            case R.id.action_share:
+                shareLog();
+                return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    public void lockFloor(View view) {
+        askFloor();
+    }
+
+    @Override
+    public void onLocationChanged(IALocation location) {
+        log(String.format(Locale.US, "%f,%f, accuracy: %.2f, certainty: %.2f",
+                location.getLatitude(), location.getLongitude(), location.getAccuracy(),
+                location.getFloorCertainty()));
+    }
+
+    @Override
+    public void onStatusChanged(String provider, int status, Bundle extras) {
+        switch (status) {
+            case IALocationManager.STATUS_CALIBRATION_CHANGED:
+                String quality = "unknown";
+                switch (extras.getInt("quality")) {
+                    case IALocationManager.CALIBRATION_POOR:
+                        quality = "Poor";
+                        break;
+                    case IALocationManager.CALIBRATION_GOOD:
+                        quality = "Good";
+                        break;
+                    case IALocationManager.CALIBRATION_EXCELLENT:
+                        quality = "Excellent";
+                        break;
+                }
+                log("Calibration change. Quality: " + quality);
+                break;
+            case IALocationManager.STATUS_AVAILABLE:
+                log("onStatusChanged: Available");
+                break;
+            case IALocationManager.STATUS_LIMITED:
+                log("onStatusChanged: Limited");
+                break;
+            case IALocationManager.STATUS_OUT_OF_SERVICE:
+                log("onStatusChanged: Out of service");
+                break;
+            case IALocationManager.STATUS_TEMPORARILY_UNAVAILABLE:
+                log("onStatusChanged: Temporarily unavailable");
+        }
+    }
+
+    @Override
+    public void onEnterRegion(IARegion region) {
+        log("onEnterRegion: " + regionType(region.getType()) + ", " + region.getId());
+    }
+
+    @Override
+    public void onExitRegion(IARegion region) {
+        log("onExitRegion: " + regionType(region.getType()) + ", " + region.getId());
+    }
+
+    /**
+     * Turn {@link IARegion#getType()} to human-readable name
+     */
+    private String regionType(int type) {
+        switch (type) {
+            case IARegion.TYPE_UNKNOWN:
+                return "unknown";
+            case IARegion.TYPE_FLOOR_PLAN:
+                return "floor plan";
+            case IARegion.TYPE_VENUE:
+                return "venue";
+            default:
+                return Integer.toString(type);
+        }
+    }
+
+    /**
+     * Append message into log prefixing with duration since start of location requests.
+     */
+    private void log(String msg) {
+        double duration = mRequestStartTime != 0
+                ? (SystemClock.elapsedRealtime() - mRequestStartTime) / 1e3
+                : 0d;
+        mLog.append(String.format(Locale.US, "\n[%06.2f]: %s", duration, msg));
+        mScrollView.smoothScrollBy(0, mLog.getBottom());
+    }
+
+    private void askFloor() {
+
+        final int minValue = -10;
+        final int maxValue = 10;
+        final NumberPicker numberPicker = new NumberPicker(this);
+        numberPicker.setMinValue(0);
+        numberPicker.setMaxValue(maxValue - minValue);
+        numberPicker.setValue(10);
+        numberPicker.setFormatter(new NumberPicker.Formatter() {
+            @Override
+            public String format(int index) {
+                return Integer.toString(index + minValue);
+            }
+        });
+
+        android.support.v7.app.AlertDialog.Builder builder =
+                new android.support.v7.app.AlertDialog.Builder(this);
+        builder.setTitle("Lock / unlock floor");
+        builder.setMessage("Floor number:");
+        builder.setView(numberPicker);
+        builder.setPositiveButton("Lock floor", new Dialog.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                if (mLocationManager != null) {
+                    int number = numberPicker.getValue() + minValue;
+                    mLocationManager.lockFloor(number);
+                    log("Locking floor " + number);
+                }
+                dialog.cancel();
+            }
+        });
+        builder.setNeutralButton("Cancel", new Dialog.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                dialog.cancel();
+            }
+        });
+        builder.setNegativeButton("Unlock", new Dialog.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                if (mLocationManager != null) {
+                    mLocationManager.unlockFloor();
+                    log("Unlocking floor");
+                }
+                dialog.cancel();
+            }
+        });
+        builder.show();
+    }
+
+    public void lockIndoors(View view) {
+        if (mLocationManager != null) {
+            mLocationManager.lockIndoors(true);
+            log("Locking indoors");
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle savedInstanceState) {
+        savedInstanceState.putLong(FASTEST_INTERVAL, mFastestInterval);
+        savedInstanceState.putFloat(SHORTEST_DISPLACEMENT, mShortestDisplacement);
+        super.onSaveInstanceState(savedInstanceState);
+    }
+
+    /**
+     * Share current log content using registered apps.
+     */
+    private void shareLog() {
+        Intent sendIntent = new Intent()
+                .setAction(Intent.ACTION_SEND)
+                .putExtra(Intent.EXTRA_TEXT, mLog.getText())
+                .setType("text/plain");
+        startActivity(sendIntent);
+    }
+
+}

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/mapsoverlay/MapsOverlayActivity.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/mapsoverlay/MapsOverlayActivity.java
@@ -6,7 +6,6 @@ import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
 import android.os.Bundle;
-import android.os.Looper;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.FragmentActivity;
 import android.util.Log;
@@ -38,10 +37,6 @@ import com.indooratlas.android.sdk.examples.utils.ExampleUtils;
 import com.indooratlas.android.sdk.resources.IAFloorPlan;
 import com.indooratlas.android.sdk.resources.IALatLng;
 import com.indooratlas.android.sdk.resources.IALocationListenerSupport;
-import com.indooratlas.android.sdk.resources.IAResourceManager;
-import com.indooratlas.android.sdk.resources.IAResult;
-import com.indooratlas.android.sdk.resources.IAResultCallback;
-import com.indooratlas.android.sdk.resources.IATask;
 import com.squareup.picasso.Picasso;
 import com.squareup.picasso.RequestCreator;
 import com.squareup.picasso.Target;
@@ -60,8 +55,6 @@ public class MapsOverlayActivity extends FragmentActivity implements LocationLis
     private IARegion mOverlayFloorPlan = null;
     private GroundOverlay mGroundOverlay = null;
     private IALocationManager mIALocationManager;
-    private IAResourceManager mResourceManager;
-    private IATask<IAFloorPlan> mFetchFloorPlanTask;
     private Target mLoadTarget;
     private boolean mCameraPositionNeedsUpdating = true; // update on first location
     private boolean mShowIndoorLocation = false;
@@ -143,7 +136,7 @@ public class MapsOverlayActivity extends FragmentActivity implements LocationLis
                         mGroundOverlay = null;
                     }
                     mOverlayFloorPlan = region; // overlay will be this (unless error in loading)
-                    fetchFloorPlan(newId);
+                    fetchFloorPlanBitmap(region.getFloorPlan());
                 } else {
                     mGroundOverlay.setTransparency(0.0f);
                 }
@@ -205,9 +198,8 @@ public class MapsOverlayActivity extends FragmentActivity implements LocationLis
         // prevent the screen going to sleep while app is on foreground
         findViewById(android.R.id.content).setKeepScreenOn(true);
 
-        // instantiate IALocationManager and IAResourceManager
+        // instantiate IALocationManager
         mIALocationManager = IALocationManager.create(this);
-        mResourceManager = IAResourceManager.create(this);
 
         startListeningPlatformLocations();
 
@@ -322,50 +314,6 @@ public class MapsOverlayActivity extends FragmentActivity implements LocationLis
         }
 
         request.into(mLoadTarget);
-    }
-
-
-    /**
-     * Fetches floor plan data from IndoorAtlas server.
-     */
-    private void fetchFloorPlan(String id) {
-
-        // if there is already running task, cancel it
-        cancelPendingNetworkCalls();
-
-        final IATask<IAFloorPlan> task = mResourceManager.fetchFloorPlanWithId(id);
-
-        task.setCallback(new IAResultCallback<IAFloorPlan>() {
-
-            @Override
-            public void onResult(IAResult<IAFloorPlan> result) {
-
-                if (result.isSuccess() && result.getResult() != null) {
-                    // retrieve bitmap for this floor plan metadata
-                    fetchFloorPlanBitmap(result.getResult());
-                } else {
-                    // ignore errors if this task was already canceled
-                    if (!task.isCancelled()) {
-                        // do something with error
-                        showInfo("Loading floor plan failed: " + result.getError());
-                        mOverlayFloorPlan = null;
-                    }
-                }
-            }
-        }, Looper.getMainLooper()); // deliver callbacks using main looper
-
-        // keep reference to task so that it can be canceled if needed
-        mFetchFloorPlanTask = task;
-
-    }
-
-    /**
-     * Helper method to cancel current task if any.
-     */
-    private void cancelPendingNetworkCalls() {
-        if (mFetchFloorPlanTask != null && !mFetchFloorPlanTask.isCancelled()) {
-            mFetchFloorPlanTask.cancel();
-        }
     }
 
     private void showInfo(String text) {

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/mapsoverlay/MapsOverlayActivity.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/mapsoverlay/MapsOverlayActivity.java
@@ -278,29 +278,28 @@ public class MapsOverlayActivity extends FragmentActivity implements LocationLis
     private void fetchFloorPlanBitmap(final IAFloorPlan floorPlan) {
 
         final String url = floorPlan.getUrl();
+        mLoadTarget = new Target() {
 
-        if (mLoadTarget == null) {
-            mLoadTarget = new Target() {
-
-                @Override
-                public void onBitmapLoaded(Bitmap bitmap, Picasso.LoadedFrom from) {
-                    Log.d(TAG, "onBitmap loaded with dimensions: " + bitmap.getWidth() + "x"
-                            + bitmap.getHeight());
+            @Override
+            public void onBitmapLoaded(Bitmap bitmap, Picasso.LoadedFrom from) {
+                Log.d(TAG, "onBitmap loaded with dimensions: " + bitmap.getWidth() + "x"
+                        + bitmap.getHeight());
+                if (mOverlayFloorPlan != null && floorPlan.getId().equals(mOverlayFloorPlan.getId())) {
                     setupGroundOverlay(floorPlan, bitmap);
                 }
+            }
 
-                @Override
-                public void onPrepareLoad(Drawable placeHolderDrawable) {
-                    // N/A
-                }
+            @Override
+            public void onPrepareLoad(Drawable placeHolderDrawable) {
+                // N/A
+            }
 
-                @Override
-                public void onBitmapFailed(Drawable placeHolderDraweble) {
-                    showInfo("Failed to load bitmap");
-                    mOverlayFloorPlan = null;
-                }
-            };
-        }
+            @Override
+            public void onBitmapFailed(Drawable placeHolderDrawable) {
+                showInfo("Failed to load bitmap");
+                mOverlayFloorPlan = null;
+            }
+        };
 
         RequestCreator request = Picasso.with(this).load(url);
 

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/osmdroid/OpenStreetMapOverlay.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/osmdroid/OpenStreetMapOverlay.java
@@ -223,30 +223,29 @@ public class OpenStreetMapOverlay extends Activity {
     private void fetchFloorPlanBitmap(final IAFloorPlan floorPlan) {
 
         final String url = floorPlan.getUrl();
+        mLoadTarget = new Target() {
 
-        if (mLoadTarget == null) {
-            mLoadTarget = new Target() {
-
-                @Override
-                public void onBitmapLoaded(Bitmap bitmap, Picasso.LoadedFrom from) {
-                    Log.d(TAG, "onBitmap loaded with dimensions: " + bitmap.getWidth() + "x"
-                            + bitmap.getHeight());
+            @Override
+            public void onBitmapLoaded(Bitmap bitmap, Picasso.LoadedFrom from) {
+                Log.d(TAG, "onBitmap loaded with dimensions: " + bitmap.getWidth() + "x"
+                        + bitmap.getHeight());
+                if (mOverlayFloorPlan != null && floorPlan.getId().equals(mOverlayFloorPlan.getId())) {
                     setupGroundOverlay(floorPlan, bitmap);
                 }
+            }
 
-                @Override
-                public void onPrepareLoad(Drawable placeHolderDrawable) {
-                    // N/A
-                }
+            @Override
+            public void onPrepareLoad(Drawable placeHolderDrawable) {
+                // N/A
+            }
 
-                @Override
-                public void onBitmapFailed(Drawable placeHolderDraweble) {
-                    Toast.makeText(OpenStreetMapOverlay.this, "Failed to load bitmap",
-                            Toast.LENGTH_SHORT).show();
-                    mOverlayFloorPlan = null;
-                }
-            };
-        }
+            @Override
+            public void onBitmapFailed(Drawable placeHolderDrawable) {
+                Toast.makeText(OpenStreetMapOverlay.this, "Failed to load bitmap",
+                        Toast.LENGTH_SHORT).show();
+                mOverlayFloorPlan = null;
+            }
+        };
 
         RequestCreator request = Picasso.with(this).load(url);
 

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/sharelocation/ShareLocationActivity.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/sharelocation/ShareLocationActivity.java
@@ -31,10 +31,6 @@ import com.indooratlas.android.sdk.examples.sharelocation.view.MultiLocationMapV
 import com.indooratlas.android.sdk.examples.utils.ExampleUtils;
 import com.indooratlas.android.sdk.resources.IAFloorPlan;
 import com.indooratlas.android.sdk.resources.IALocationListenerSupport;
-import com.indooratlas.android.sdk.resources.IAResourceManager;
-import com.indooratlas.android.sdk.resources.IAResult;
-import com.indooratlas.android.sdk.resources.IAResultCallback;
-import com.indooratlas.android.sdk.resources.IATask;
 
 /**
  * Simple example of sharing ones location with others on the same map. Uses PubNub cloud service
@@ -49,8 +45,6 @@ public class ShareLocationActivity extends AppCompatActivity {
 
     private IALocationManager mLocationManager;
 
-    private IAResourceManager mResourceManager;
-
     private LocationChannel mLocationChannel;
 
     private LocationSource mMyLocationSource;
@@ -58,8 +52,6 @@ public class ShareLocationActivity extends AppCompatActivity {
     private View mCoordinatorLayout;
 
     private MultiLocationMapView mMapView;
-
-    private IATask<IAFloorPlan> mFetchFloorPlanTask;
 
     private String mCustomChannelName;
 
@@ -71,7 +63,6 @@ public class ShareLocationActivity extends AppCompatActivity {
         mMapView = (MultiLocationMapView) findViewById(R.id.map);
 
         mLocationManager = IALocationManager.create(this);
-        mResourceManager = IAResourceManager.create(this);
 
         mLocationChannel = new PubNubLocationChannelImpl(
                 getString(R.string.pubnub_publish_key),
@@ -223,36 +214,6 @@ public class ShareLocationActivity extends AppCompatActivity {
     }
 
     /**
-     * Start loading floor plan bitmap
-     */
-    private void updateMapBitmap(IARegion region) {
-
-        if (region.getType() != IARegion.TYPE_FLOOR_PLAN) {
-            return;
-        }
-
-        if (mFetchFloorPlanTask != null && !mFetchFloorPlanTask.isCancelled()) {
-            mFetchFloorPlanTask.cancel();
-        }
-
-        final IATask<IAFloorPlan> task = mResourceManager.fetchFloorPlanWithId(region.getId());
-        mFetchFloorPlanTask = task;
-        task.setCallback(new IAResultCallback<IAFloorPlan>() {
-            @Override
-            public void onResult(IAResult<IAFloorPlan> result) {
-                if (result.isSuccess() && result.getResult() != null) {
-                    mMapView.setFloorPlan(result.getResult());
-                } else {
-                    if (!task.isCancelled()) {
-                        showError(getString(R.string.error_loading_floor_plan));
-                    }
-                }
-            }
-        }, Looper.getMainLooper());
-
-    }
-
-    /**
      * Handle events related to location changes.
      */
     private IALocationListener mLocationChangeHandler = new IALocationListenerSupport() {
@@ -277,7 +238,7 @@ public class ShareLocationActivity extends AppCompatActivity {
             Log.d(SharingUtils.TAG, "onEnterRegion: " + region);
             if (region.getType() == IARegion.TYPE_FLOOR_PLAN && !hasCustomChannel()) {
                 setChannel(region.getId(), false); // set automatically selected channel
-                updateMapBitmap(region);
+                mMapView.setFloorPlan(region.getFloorPlan());
             }
         }
 

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/wayfinding/WayfindingOverlayActivity.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/wayfinding/WayfindingOverlayActivity.java
@@ -176,19 +176,14 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Googl
         @Override
         public void onEnterRegion(IARegion region) {
             if (region.getType() == IARegion.TYPE_FLOOR_PLAN) {
-                final String newId = region.getId();
-                // Are we entering a new floor plan or coming back the floor plan we just left?
-                if (mGroundOverlay == null || !region.equals(mOverlayFloorPlan)) {
-                    mCameraPositionNeedsUpdating = true; // entering new fp, need to move camera
-                    if (mGroundOverlay != null) {
-                        mGroundOverlay.remove();
-                        mGroundOverlay = null;
-                    }
-                    mOverlayFloorPlan = region; // overlay will be this (unless error in loading)
-                    fetchFloorPlanBitmap(region.getFloorPlan());
-                } else {
-                    mGroundOverlay.setTransparency(0.0f);
+                Log.d(TAG, "enter floor plan " + region.getId());
+                mCameraPositionNeedsUpdating = true; // entering new fp, need to move camera
+                if (mGroundOverlay != null) {
+                    mGroundOverlay.remove();
+                    mGroundOverlay = null;
                 }
+                mOverlayFloorPlan = region; // overlay will be this (unless error in loading)
+                fetchFloorPlanBitmap(region.getFloorPlan());
             }
         }
 
@@ -295,32 +290,37 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Googl
      */
     private void fetchFloorPlanBitmap(final IAFloorPlan floorPlan) {
 
-        final String url = floorPlan.getUrl();
-
-        if (mLoadTarget == null) {
-            mLoadTarget = new Target() {
-
-                @Override
-                public void onBitmapLoaded(Bitmap bitmap, Picasso.LoadedFrom from) {
-                    Log.d(TAG, "onBitmap loaded with dimensions: " + bitmap.getWidth() + "x"
-                            + bitmap.getHeight());
-                    if (mOverlayFloorPlan != null && floorPlan.getId().equals(mOverlayFloorPlan.getId())) {
-                        setupGroundOverlay(floorPlan, bitmap);
-                    }
-                }
-
-                @Override
-                public void onPrepareLoad(Drawable placeHolderDrawable) {
-                    // N/A
-                }
-
-                @Override
-                public void onBitmapFailed(Drawable placeHolderDraweble) {
-                    showInfo("Failed to load bitmap");
-                    mOverlayFloorPlan = null;
-                }
-            };
+        if (floorPlan == null) {
+            Log.e(TAG, "null floor plan in fetchFloorPlanBitmap");
+            return;
         }
+
+        final String url = floorPlan.getUrl();
+        Log.d(TAG, "loading floor plan bitmap from "+url);
+
+        mLoadTarget = new Target() {
+
+            @Override
+            public void onBitmapLoaded(Bitmap bitmap, Picasso.LoadedFrom from) {
+                Log.d(TAG, "onBitmap loaded with dimensions: " + bitmap.getWidth() + "x"
+                        + bitmap.getHeight());
+                if (mOverlayFloorPlan != null && floorPlan.getId().equals(mOverlayFloorPlan.getId())) {
+                    Log.d(TAG, "showing overlay");
+                    setupGroundOverlay(floorPlan, bitmap);
+                }
+            }
+
+            @Override
+            public void onPrepareLoad(Drawable placeHolderDrawable) {
+                // N/A
+            }
+
+            @Override
+            public void onBitmapFailed(Drawable placeHolderDrawable) {
+                showInfo("Failed to load bitmap");
+                mOverlayFloorPlan = null;
+            }
+        };
 
         RequestCreator request = Picasso.with(this).load(url);
 

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/wayfinding/WayfindingOverlayActivity.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/wayfinding/WayfindingOverlayActivity.java
@@ -374,7 +374,16 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Googl
     }
 
     private boolean hasArrivedToDestination(IARoute route) {
-        return route.getLegs().size() == 1 && route.getLegs().get(0).getLength() < 10.0;
+        // empty routes are only returned when there is a problem, for example,
+        // missing or disconnected routing graph
+        if (route.getLegs().size() == 0) {
+            return false;
+        }
+
+        final double FINISH_THRESHOLD_METERS = 8.0;
+        double routeLength = 0;
+        for (IARoute.Leg leg : route.getLegs()) routeLength += leg.getLength();
+        return routeLength < FINISH_THRESHOLD_METERS;
     }
 
     /**

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/wayfinding/WayfindingOverlayActivity.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/wayfinding/WayfindingOverlayActivity.java
@@ -1,13 +1,9 @@
 package com.indooratlas.android.sdk.examples.wayfinding;
 
 import android.Manifest;
-import android.content.Context;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
-import android.location.Location;
-import android.location.LocationListener;
-import android.location.LocationManager;
 import android.os.Bundle;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.ActivityCompat;
@@ -33,6 +29,8 @@ import com.indooratlas.android.sdk.IALocation;
 import com.indooratlas.android.sdk.IALocationListener;
 import com.indooratlas.android.sdk.IALocationManager;
 import com.indooratlas.android.sdk.IALocationRequest;
+import com.indooratlas.android.sdk.IAOrientationListener;
+import com.indooratlas.android.sdk.IAOrientationRequest;
 import com.indooratlas.android.sdk.IARegion;
 import com.indooratlas.android.sdk.IARoute;
 import com.indooratlas.android.sdk.IAWayfindingListener;
@@ -52,8 +50,7 @@ import java.util.List;
 import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 
 @SdkExample(description = R.string.example_wayfinding_description)
-public class WayfindingOverlayActivity extends FragmentActivity implements LocationListener,
-        GoogleMap.OnMapClickListener {
+public class WayfindingOverlayActivity extends FragmentActivity implements GoogleMap.OnMapClickListener {
     private static final int MY_PERMISSION_ACCESS_FINE_LOCATION = 42;
 
     private static final String TAG = "IndoorAtlasExample";
@@ -68,8 +65,8 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Locat
     private IALocationManager mIALocationManager;
     private Target mLoadTarget;
     private boolean mCameraPositionNeedsUpdating = true; // update on first location
-    private boolean mShowIndoorLocation = false;
     private Marker mDestinationMarker;
+    private Marker mHeadingMarker;
     private List<Polyline> mPolylines = new ArrayList<>();
     private IARoute mCurrentRoute;
 
@@ -78,7 +75,26 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Locat
         @Override
         public void onWayfindingUpdate(IARoute route) {
             mCurrentRoute = route;
+            if (hasArrivedToDestination(route)) {
+                // stop wayfinding
+                showInfo("You're there!");
+                mCurrentRoute = null;
+                mWayfindingDestination = null;
+                mIALocationManager.removeWayfindingUpdates();
+            }
             updateRouteVisualization();
+        }
+    };
+
+    private IAOrientationListener mOrientationListener = new IAOrientationListener() {
+        @Override
+        public void onHeadingChanged(long timestamp, double heading) {
+            updateHeading(heading);
+        }
+
+        @Override
+        public void onOrientationChange(long timestamp, double[] quaternion) {
+            // we do not need full device orientation in this example, just the heading
         }
     };
 
@@ -91,16 +107,28 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Locat
                 mCircle = mMap.addCircle(new CircleOptions()
                         .center(center)
                         .radius(accuracyRadius)
-                        .fillColor(0x801681FB)
-                        .strokeColor(0x800A78DD)
+                        .fillColor(0x201681FB)
+                        .strokeColor(0x500A78DD)
                         .zIndex(1.0f)
                         .visible(true)
                         .strokeWidth(5.0f));
+                mHeadingMarker = mMap.addMarker(new MarkerOptions()
+                        .position(center)
+                        .icon(BitmapDescriptorFactory.fromResource(R.drawable.map_blue_dot))
+                        .anchor(0.5f, 0.5f)
+                        .flat(true));
             }
         } else {
             // move existing markers position to received location
             mCircle.setCenter(center);
+            mHeadingMarker.setPosition(center);
             mCircle.setRadius(accuracyRadius);
+        }
+    }
+
+    private void updateHeading(double heading) {
+        if (mHeadingMarker != null) {
+            mHeadingMarker.setRotation((float)heading);
         }
     }
 
@@ -131,9 +159,7 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Locat
             }
             mFloor = newFloor;
 
-            if (mShowIndoorLocation) {
-                showLocationCircle(center, location.getAccuracy());
-            }
+            showLocationCircle(center, location.getAccuracy());
 
             // our camera position needs updating if location has significantly changed
             if (mCameraPositionNeedsUpdating) {
@@ -163,66 +189,15 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Locat
                 } else {
                     mGroundOverlay.setTransparency(0.0f);
                 }
-
-                mShowIndoorLocation = true;
-                showInfo("Showing IndoorAtlas SDK\'s location output");
             }
-            showInfo("Enter " + (region.getType() == IARegion.TYPE_VENUE
-                    ? "VENUE "
-                    : "FLOOR_PLAN ") + region.getId());
         }
 
         @Override
         public void onExitRegion(IARegion region) {
-            if (mGroundOverlay != null) {
-                // Indicate we left this floor plan but leave it there for reference
-                // If we enter another floor plan, this one will be removed and another one loaded
-                mGroundOverlay.setTransparency(0.5f);
-            }
-
-            mShowIndoorLocation = false;
-            showInfo("Exit " + (region.getType() == IARegion.TYPE_VENUE
-                    ? "VENUE "
-                    : "FLOOR_PLAN ") + region.getId());
         }
 
     };
 
-    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-        switch (requestCode) {
-            case MY_PERMISSION_ACCESS_FINE_LOCATION: {
-                if (grantResults.length > 0
-                        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    startListeningPlatformLocations();
-                }
-                break;
-            }
-        }
-    }
-
-    @Override
-    public void onLocationChanged(Location location) {
-        if (!mShowIndoorLocation) {
-            Log.d(TAG, "new LocationService location received with coordinates: " + location.getLatitude()
-                    + "," + location.getLongitude());
-
-            showLocationCircle(
-                    new LatLng(location.getLatitude(), location.getLongitude()),
-                    location.getAccuracy());
-        }
-    }
-
-    @Override
-    public void onProviderDisabled(String provider) {
-    }
-
-    @Override
-    public void onProviderEnabled(String provider) {
-    }
-
-    @Override
-    public void onStatusChanged(String provider, int status, Bundle extras) {
-    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -243,8 +218,6 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Locat
             ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, MY_PERMISSION_ACCESS_FINE_LOCATION);
             return;
         }
-
-        startListeningPlatformLocations();
     }
 
     @Override
@@ -268,6 +241,10 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Locat
         // start receiving location updates & monitor region changes
         mIALocationManager.requestLocationUpdates(IALocationRequest.create(), mListener);
         mIALocationManager.registerRegionListener(mRegionListener);
+        mIALocationManager.registerOrientationListener(
+                // update if heading changes by 1 degrees or more
+                new IAOrientationRequest(1, 0),
+                mOrientationListener);
 
         if (mWayfindingDestination != null) {
             mIALocationManager.requestWayfindingUpdates(mWayfindingDestination, mWayfindingListener);
@@ -282,6 +259,7 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Locat
         // unregister location & region changes
         mIALocationManager.removeLocationUpdates(mListener);
         mIALocationManager.unregisterRegionListener(mRegionListener);
+        mIALocationManager.unregisterOrientationListener(mOrientationListener);
 
         if (mWayfindingDestination != null) {
             mIALocationManager.removeWayfindingUpdates();
@@ -326,7 +304,9 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Locat
                 public void onBitmapLoaded(Bitmap bitmap, Picasso.LoadedFrom from) {
                     Log.d(TAG, "onBitmap loaded with dimensions: " + bitmap.getWidth() + "x"
                             + bitmap.getHeight());
-                    setupGroundOverlay(floorPlan, bitmap);
+                    if (mOverlayFloorPlan != null && floorPlan.getId().equals(mOverlayFloorPlan.getId())) {
+                        setupGroundOverlay(floorPlan, bitmap);
+                    }
                 }
 
                 @Override
@@ -368,14 +348,6 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Locat
         snackbar.show();
     }
 
-    private void startListeningPlatformLocations() {
-        LocationManager locationManager = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
-        if (locationManager != null && (ActivityCompat.checkSelfPermission(this, ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED)) {
-            locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, 0, 0, this);
-            locationManager.requestLocationUpdates(LocationManager.NETWORK_PROVIDER, 0, 0, this);
-        }
-    }
-
     @Override
     public void onMapClick(LatLng point) {
         if (mMap != null) {
@@ -401,6 +373,10 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Locat
         }
     }
 
+    private boolean hasArrivedToDestination(IARoute route) {
+        return route.getLegs().size() == 1 && route.getLegs().get(0).getLength() < 10.0;
+    }
+
     /**
      * Clear the visualizations for the wayfinding paths
      */
@@ -423,6 +399,17 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Locat
         }
 
         for (IARoute.Leg leg : mCurrentRoute.getLegs()) {
+
+            if (leg.getEdgeIndex() == null) {
+                // Legs without an edge index are, in practice, the last and first legs of the
+                // route. They connect the destination or current location to the routing graph.
+                // All other legs travel along the edges of the routing graph.
+
+                // Omitting these "artificial edges" in visualization can improve the aesthetics
+                // of the route. Alternatively, they could be visualized with dashed lines.
+                continue;
+            }
+
             PolylineOptions opt = new PolylineOptions();
             opt.add(new LatLng(leg.getBegin().getLatitude(), leg.getBegin().getLongitude()));
             opt.add(new LatLng(leg.getEnd().getLatitude(), leg.getEnd().getLongitude()));
@@ -434,6 +421,7 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Locat
             } else {
                 opt.color(0x300000FF);
             }
+
             mPolylines.add(mMap.addPolyline(opt));
         }
     }

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/wayfinding/WayfindingOverlayActivity.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/wayfinding/WayfindingOverlayActivity.java
@@ -13,6 +13,7 @@ import android.view.View;
 
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
@@ -50,7 +51,8 @@ import java.util.List;
 import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 
 @SdkExample(description = R.string.example_wayfinding_description)
-public class WayfindingOverlayActivity extends FragmentActivity implements GoogleMap.OnMapClickListener {
+public class WayfindingOverlayActivity extends FragmentActivity
+        implements GoogleMap.OnMapClickListener, OnMapReadyCallback {
     private static final int MY_PERMISSION_ACCESS_FINE_LOCATION = 42;
 
     private static final String TAG = "IndoorAtlasExample";
@@ -59,6 +61,7 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Googl
     private static final int MAX_DIMENSION = 2048;
 
     private GoogleMap mMap; // Might be null if Google Play services APK is not available.
+
     private Circle mCircle;
     private IARegion mOverlayFloorPlan = null;
     private GroundOverlay mGroundOverlay = null;
@@ -213,6 +216,11 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Googl
             ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, MY_PERMISSION_ACCESS_FINE_LOCATION);
             return;
         }
+
+        // Try to obtain the map from the SupportMapFragment.
+        ((SupportMapFragment) getSupportFragmentManager()
+                .findFragmentById(R.id.map))
+                .getMapAsync(this);
     }
 
     @Override
@@ -226,12 +234,6 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Googl
     @Override
     protected void onResume() {
         super.onResume();
-        if (mMap == null) {
-            // Try to obtain the map from the SupportMapFragment.
-            mMap = ((SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map))
-                    .getMap();
-            mMap.setMyLocationEnabled(false);
-        }
 
         // start receiving location updates & monitor region changes
         mIALocationManager.requestLocationUpdates(IALocationRequest.create(), mListener);
@@ -244,8 +246,6 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Googl
         if (mWayfindingDestination != null) {
             mIALocationManager.requestWayfindingUpdates(mWayfindingDestination, mWayfindingListener);
         }
-
-        mMap.setOnMapClickListener(this);
     }
 
     @Override
@@ -261,6 +261,13 @@ public class WayfindingOverlayActivity extends FragmentActivity implements Googl
         }
     }
 
+    @Override
+    public void onMapReady(GoogleMap googleMap) {
+        mMap = googleMap;
+        // do not show Google's outdoor location
+        mMap.setMyLocationEnabled(false);
+        mMap.setOnMapClickListener(this);
+    }
 
     /**
      * Sets bitmap of floor plan as ground overlay on Google Maps

--- a/Basic/src/main/res/layout/activity_lockfloor.xml
+++ b/Basic/src/main/res/layout/activity_lockfloor.xml
@@ -1,0 +1,48 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:tools="http://schemas.android.com/tools"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:paddingBottom="@dimen/activity_vertical_margin"
+                android:paddingLeft="@dimen/activity_horizontal_margin"
+                android:paddingRight="@dimen/activity_horizontal_margin"
+                android:paddingTop="@dimen/activity_vertical_margin"
+                tools:context=".LocationManagerActivity">
+
+    <LinearLayout
+        android:id="@+id/buttons"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:orientation="horizontal">
+
+        <Button
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight=".3"
+            android:onClick="lockFloor"
+            android:text="Set floor lock"/>
+
+        <Button
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight=".3"
+            android:onClick="lockIndoors"
+            android:text="Set indoor lock"/>
+
+    </LinearLayout>
+
+    <ScrollView
+        android:id="@+id/scroller"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_above="@id/buttons">
+
+        <TextView
+            android:id="@+id/text"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="top"
+            android:textAppearance="?android:textAppearanceSmall"/>
+    </ScrollView>
+
+</RelativeLayout>

--- a/Basic/src/main/res/values/strings.xml
+++ b/Basic/src/main/res/values/strings.xml
@@ -98,5 +98,8 @@
     <string name="example_foregroundservice_description">Demonstrates IndoorAtlas background positioning using a foreground service.</string>
     <string name="example_foregroundservice_title">14. Foreground Service</string>
 
+    <string name="example_lockfloor_description">Demonstrates how locking positioning to specific floor or indoors is achieved.</string>
+    <string name="example_lockfloor_title">15. Lock floor and Indoors </string>
+
 
 </resources>


### PR DESCRIPTION
 * change SDK version to 2.9.0-beta-931
 * remove `IAResourceManager` and explicit floor plans
 * use SDK 2.9 region events
 * add some floor lock and indoor lock (used in the wayfinding example) samples
 * fix asynchronity issues in floor plan fetching
 * use SDK 2.9 integrated wayfinding
 * show heading arrow in the wayfinding example