### PR TITLE
Fix osmdroid map loading

### DIFF
--- a/Basic/build.gradle
+++ b/Basic/build.gradle
@@ -6,10 +6,10 @@ android {
     buildToolsVersion '26.0.3'
 
     // note: use gradle.properties in project root level to set your api credentials
-    def apiKey = project.properties['indoorAtlasApiKey'] ?: "api-key-not-set";
-    def apiSecret = project.properties['indoorAtlasApiSecret'] ?: "api-secret-not-set";
-    def pubNubPublishKey = project.properties['pubNubPublishKey'] ?: "not-set";
-    def pubNubSubscribeKey = project.properties['pubNubSubscribeKey'] ?: "not-set";
+    def apiKey = project.properties['indoorAtlasApiKey'] ?: "api-key-not-set"
+    def apiSecret = project.properties['indoorAtlasApiSecret'] ?: "api-secret-not-set"
+    def pubNubPublishKey = project.properties['pubNubPublishKey'] ?: "not-set"
+    def pubNubSubscribeKey = project.properties['pubNubSubscribeKey'] ?: "not-set"
 
 
     defaultConfig {
@@ -50,17 +50,17 @@ android {
 }
 
 dependencies {
-    compile "com.indooratlas.android:indooratlas-android-sdk:3.0.0-beta-1021@aar"
+    implementation "com.indooratlas.android:indooratlas-android-sdk:3.0.0-beta-1021@aar"
 
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'com.google.android.gms:play-services-maps:8.1.0'
-    compile 'com.google.maps.android:android-maps-utils:0.3.+'
-    compile 'com.squareup.picasso:picasso:2.5.2'
-    compile 'com.davemorrissey.labs:subsampling-scale-image-view:3.2.0'
-    compile 'com.pubnub:pubnub-android:3.7.5'
-    compile 'com.android.support:design:26.1.0'
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.google.android.gms:play-services-maps:8.1.0'
+    implementation 'com.google.maps.android:android-maps-utils:0.3.+'
+    implementation 'com.squareup.picasso:picasso:2.5.2'
+    implementation 'com.davemorrissey.labs:subsampling-scale-image-view:3.2.0'
+    implementation 'com.pubnub:pubnub-android:3.7.5'
+    implementation 'com.android.support:design:26.1.0'
 
     // for Open Street Map support
-    compile 'org.osmdroid:osmdroid-android:6.0.2'
-    compile 'com.github.MKergall:osmbonuspack:6.5.2'
+    implementation 'org.osmdroid:osmdroid-android:6.0.3'
+    implementation 'com.github.MKergall:osmbonuspack:6.5.2'
 }

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/osmdroid/OpenStreetMapOverlay.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/osmdroid/OpenStreetMapOverlay.java
@@ -34,6 +34,7 @@ import org.osmdroid.bonuspack.overlays.GroundOverlay;
 import org.osmdroid.config.Configuration;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
 import org.osmdroid.util.GeoPoint;
+import org.osmdroid.views.CustomZoomButtonsController;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.CopyrightOverlay;
 import org.osmdroid.views.overlay.gestures.RotationGestureOverlay;
@@ -226,7 +227,8 @@ public class OpenStreetMapOverlay extends Activity {
             mRotationGestureOverlay.setEnabled(true);
             mOsmv.getOverlayManager().add(mRotationGestureOverlay);
             mOsmv.setMultiTouchControls(true);
-            mOsmv.setBuiltInZoomControls(false); // gestures fill this role
+            // gestures fill this role
+            mOsmv.getZoomController().setVisibility(CustomZoomButtonsController.Visibility.NEVER);
 
             mCopyrightOverlay = new CopyrightOverlay(this);
             mOsmv.getOverlayManager().add(mCopyrightOverlay);

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/osmdroid/OpenStreetMapOverlay.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/osmdroid/OpenStreetMapOverlay.java
@@ -217,6 +217,8 @@ public class OpenStreetMapOverlay extends Activity {
             mOsmv = new MapView(this);
             mOsmv.setTilesScaledToDpi(true);
 
+            // Sets up the user agent to prevent being banned from OSM servers:
+            // load(...) sets up default values, such as populating userAgent with packageName
             Configuration.getInstance().load(
                     this, PreferenceManager.getDefaultSharedPreferences(this));
 

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/osmdroid/OpenStreetMapOverlay.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/osmdroid/OpenStreetMapOverlay.java
@@ -7,6 +7,7 @@ import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
@@ -30,6 +31,7 @@ import com.squareup.picasso.RequestCreator;
 import com.squareup.picasso.Target;
 
 import org.osmdroid.bonuspack.overlays.GroundOverlay;
+import org.osmdroid.config.Configuration;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
@@ -213,6 +215,9 @@ public class OpenStreetMapOverlay extends Activity {
 
             mOsmv = new MapView(this);
             mOsmv.setTilesScaledToDpi(true);
+
+            Configuration.getInstance().load(
+                    this, PreferenceManager.getDefaultSharedPreferences(this));
 
             mOsmv.getController().setZoom(18.0);
 


### PR DESCRIPTION
Set up user agent (with config loading) to load map tiles. This apparently prevents being banned from the OSM servers:

https://www.programcreek.com/java-api-examples/?api=org.osmdroid.config.Configuration