### PR TITLE
Lib update and compatibility fixes

### DIFF
--- a/Basic/build.gradle
+++ b/Basic/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation "com.indooratlas.android:indooratlas-android-sdk:3.3.5@aar"
 
     //noinspection GradleCompatible
-    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
     //noinspection GradleCompatible
     implementation 'com.android.support:design:28.0.0'
     //noinspection GradleDependency

--- a/Basic/build.gradle
+++ b/Basic/build.gradle
@@ -50,10 +50,17 @@ android {
 dependencies {
     implementation "com.indooratlas.android:indooratlas-android-sdk:3.3.5@aar"
 
+    //noinspection GradleCompatible
     implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.google.android.gms:play-services-maps:8.1.0'
-    implementation 'com.google.maps.android:android-maps-utils:0.3.+'
+    //noinspection GradleCompatible
+    implementation 'com.android.support:design:28.0.0'
+    //noinspection GradleDependency
+    implementation 'com.google.android.gms:play-services-maps:16.1.0'
+
+    implementation 'com.google.maps.android:android-maps-utils:0.3.4'
     implementation 'com.squareup.picasso:picasso:2.5.2'
+
+    //noinspection GradleDependency
     implementation 'com.davemorrissey.labs:subsampling-scale-image-view:3.2.0'
-    implementation 'com.android.support:design:26.1.0'
+
 }

--- a/Basic/src/main/AndroidManifest.xml
+++ b/Basic/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:requestLegacyExternalStorage="true">
         <meta-data
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/ListExamplesActivity.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/ListExamplesActivity.java
@@ -66,11 +66,16 @@ public class ListExamplesActivity extends AppCompatActivity {
                             finish();
                         }
                     }).show();
-            return;
         }
 
-        ensurePermissions();
+    }
 
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (isSdkConfigured()) {
+            ensurePermissions();
+        }
     }
 
     /**
@@ -81,7 +86,7 @@ public class ListExamplesActivity extends AppCompatActivity {
         if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)
                 != PackageManager.PERMISSION_GRANTED) {
 
-            // We dont have access to FINE_LOCATION (Required by Google Maps example)
+            // We don't have access to FINE_LOCATION (Required by Google Maps example)
             // IndoorAtlas SDK has minimum requirement of COARSE_LOCATION to enable WiFi scanning
             if (ActivityCompat.shouldShowRequestPermissionRationale(this,
                     Manifest.permission.ACCESS_FINE_LOCATION)) {
@@ -202,7 +207,7 @@ public class ListExamplesActivity extends AppCompatActivity {
 
     private void parseExample(ActivityInfo info, ArrayList<ExampleEntry> list) {
         try {
-            Class cls = Class.forName(info.name);
+            Class<?> cls = Class.forName(info.name);
             if (cls.isAnnotationPresent(SdkExample.class)) {
                 SdkExample annotation = (SdkExample) cls.getAnnotation(SdkExample.class);
                 list.add(new ExampleEntry(new ComponentName(info.packageName, info.name),

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/ListExamplesActivity.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/ListExamplesActivity.java
@@ -1,6 +1,7 @@
 package com.indooratlas.android.sdk.examples;
 
 import android.Manifest;
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.ComponentName;
 import android.content.Context;
@@ -77,14 +78,17 @@ public class ListExamplesActivity extends AppCompatActivity {
         }
     }
 
+    public static boolean checkLocationPermissions(Activity activity) {
+        return ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION)
+                == PackageManager.PERMISSION_GRANTED;
+    }
+
     /**
      * Checks that we have access to required information, if not ask for users permission.
      */
     private void ensurePermissions() {
 
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)
-                != PackageManager.PERMISSION_GRANTED) {
-
+        if (!checkLocationPermissions(this)) {
             // We don't have access to FINE_LOCATION (Required by Google Maps example)
             // IndoorAtlas SDK has minimum requirement of COARSE_LOCATION to enable WiFi scanning
             if (ActivityCompat.shouldShowRequestPermissionRationale(this,
@@ -129,11 +133,11 @@ public class ListExamplesActivity extends AppCompatActivity {
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         if (requestCode == REQUEST_CODE_ACCESS_COARSE_LOCATION) {
-                if (grantResults.length == 0
-                        || grantResults[0] == PackageManager.PERMISSION_DENIED) {
-                    Toast.makeText(this, R.string.location_permission_denied_message,
-                            Toast.LENGTH_LONG).show();
-                }
+            if (grantResults.length == 0
+                    || grantResults[0] == PackageManager.PERMISSION_DENIED) {
+                Toast.makeText(this, R.string.location_permission_denied_message,
+                        Toast.LENGTH_LONG).show();
+            }
         }
     }
 

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/ListExamplesActivity.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/ListExamplesActivity.java
@@ -24,7 +24,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import java.util.ArrayList;
-import java.util.Collections;
 
 
 /**

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/ListExamplesActivity.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/ListExamplesActivity.java
@@ -10,6 +10,7 @@ import android.content.pm.ActivityInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
@@ -122,19 +123,14 @@ public class ListExamplesActivity extends AppCompatActivity {
     }
 
     @Override
-    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-
-        switch (requestCode) {
-            case REQUEST_CODE_ACCESS_COARSE_LOCATION:
-
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        if (requestCode == REQUEST_CODE_ACCESS_COARSE_LOCATION) {
                 if (grantResults.length == 0
                         || grantResults[0] == PackageManager.PERMISSION_DENIED) {
                     Toast.makeText(this, R.string.location_permission_denied_message,
                             Toast.LENGTH_LONG).show();
                 }
-                break;
         }
-
     }
 
     /**
@@ -192,10 +188,10 @@ public class ListExamplesActivity extends AppCompatActivity {
             PackageManager pm = context.getPackageManager();
             PackageInfo info = pm.getPackageInfo(packageName, PackageManager.GET_ACTIVITIES);
 
-            ActivityInfo[] activities = info.activities;
-            for (int i = 0; i < activities.length; i++) {
-                parseExample(activities[i], result);
+            for(ActivityInfo activityInfo : info.activities) {
+                parseExample(activityInfo, result);
             }
+
             return result;
 
         } catch (Exception e) {
@@ -204,7 +200,6 @@ public class ListExamplesActivity extends AppCompatActivity {
 
     }
 
-    @SuppressWarnings("unchecked")
     private void parseExample(ActivityInfo info, ArrayList<ExampleEntry> list) {
         try {
             Class cls = Class.forName(info.name);

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/geofence/GeofenceMapsOverlayActivity.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/geofence/GeofenceMapsOverlayActivity.java
@@ -1,13 +1,17 @@
 package com.indooratlas.android.sdk.examples.geofence;
 
+import android.Manifest;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
+import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.FragmentActivity;
 import android.util.Log;
 import android.view.View;
@@ -117,7 +121,7 @@ public class GeofenceMapsOverlayActivity extends FragmentActivity implements Loc
         final double radius = GEOFENCE_RADIUS_METERS;
         final int edgeCount = 12;
         final double EARTH_RADIUS_METERS = 6.371e6;
-        final double latPerMeter = 1.0/(EARTH_RADIUS_METERS * Math.PI/180);
+        final double latPerMeter = 1.0 / (EARTH_RADIUS_METERS * Math.PI / 180);
         final double lonPerMeter = latPerMeter / Math.cos(Math.PI / 180.0 * latLng.latitude);
 
         ArrayList<double[]> edges = new ArrayList<>();
@@ -283,7 +287,7 @@ public class GeofenceMapsOverlayActivity extends FragmentActivity implements Loc
                 }
 
                 mShowIndoorLocation = true;
-                showInfo("Showing IndoorAtlas SDK\'s location output");
+                showInfo("Showing IndoorAtlas SDK's location output");
             }
             showInfo("Enter " + (region.getType() == IARegion.TYPE_VENUE
                     ? "VENUE "
@@ -307,7 +311,7 @@ public class GeofenceMapsOverlayActivity extends FragmentActivity implements Loc
     };
 
     @Override
-    public void onLocationChanged(Location location) {
+    public void onLocationChanged(@NonNull Location location) {
         if (!mShowIndoorLocation) {
             Log.d(TAG, "new LocationService location received with coordinates: " + location.getLatitude()
                     + "," + location.getLongitude());
@@ -320,11 +324,11 @@ public class GeofenceMapsOverlayActivity extends FragmentActivity implements Loc
     }
 
     @Override
-    public void onProviderDisabled(String provider) {
+    public void onProviderDisabled(@NonNull String provider) {
     }
 
     @Override
-    public void onProviderEnabled(String provider) {
+    public void onProviderEnabled(@NonNull String provider) {
     }
 
     @Override
@@ -377,6 +381,11 @@ public class GeofenceMapsOverlayActivity extends FragmentActivity implements Loc
     @Override
     public void onMapReady(GoogleMap googleMap) {
         mMap = googleMap;
+
+        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            finish(); // Handle permission asking in ListExamplesActivity
+        }
+
         // do not show Google's outdoor location
         mMap.setMyLocationEnabled(false);
 

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/geofence/GeofenceMapsOverlayActivity.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/geofence/GeofenceMapsOverlayActivity.java
@@ -1,8 +1,7 @@
 package com.indooratlas.android.sdk.examples.geofence;
 
-import android.Manifest;
+import android.annotation.SuppressLint;
 import android.content.Context;
-import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.location.Location;
@@ -11,7 +10,6 @@ import android.location.LocationManager;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
-import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.FragmentActivity;
 import android.util.Log;
 import android.view.View;
@@ -39,6 +37,7 @@ import com.indooratlas.android.sdk.IALocationListener;
 import com.indooratlas.android.sdk.IALocationManager;
 import com.indooratlas.android.sdk.IALocationRequest;
 import com.indooratlas.android.sdk.IARegion;
+import com.indooratlas.android.sdk.examples.ListExamplesActivity;
 import com.indooratlas.android.sdk.examples.R;
 import com.indooratlas.android.sdk.examples.SdkExample;
 import com.indooratlas.android.sdk.resources.IAFloorPlan;
@@ -379,12 +378,14 @@ public class GeofenceMapsOverlayActivity extends FragmentActivity implements Loc
         mIALocationManager.registerRegionListener(mRegionListener);
     }
 
+    @SuppressLint("MissingPermission")
     @Override
     public void onMapReady(GoogleMap googleMap) {
         mMap = googleMap;
 
-        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+        if (!ListExamplesActivity.checkLocationPermissions(this)) {
             finish(); // Handle permission asking in ListExamplesActivity
+            return;
         }
 
         // do not show Google's outdoor location

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/geofence/GeofenceMapsOverlayActivity.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/geofence/GeofenceMapsOverlayActivity.java
@@ -95,7 +95,7 @@ public class GeofenceMapsOverlayActivity extends FragmentActivity implements Loc
             }
         }
 
-        String sb = "Geofence triggered. Geofence id: " + geofence.getId() + ". Trigger type: " +
+        String sb = "Geofence " + geofence.getName() + " triggered. Trigger type: " +
                 ((event.getGeofenceTransition() == IAGeofence.GEOFENCE_TRANSITION_ENTER) ?
                         "ENTER" : "EXIT");
 
@@ -137,6 +137,7 @@ public class GeofenceMapsOverlayActivity extends FragmentActivity implements Loc
         IAGeofence geofence = new IAGeofence.Builder()
                 .withEdges(edges)
                 .withId(geofenceId)
+                .withName(geofenceId)
                 .build();
 
 

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/wayfinding/WayfindingOverlayActivity.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/wayfinding/WayfindingOverlayActivity.java
@@ -1,9 +1,12 @@
 package com.indooratlas.android.sdk.examples.wayfinding;
 
+import android.Manifest;
+import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.design.widget.Snackbar;
+import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.FragmentActivity;
 import android.util.Log;
 import android.view.View;
@@ -256,6 +259,11 @@ public class WayfindingOverlayActivity extends FragmentActivity
     @Override
     public void onMapReady(GoogleMap googleMap) {
         mMap = googleMap;
+
+        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            finish(); // Handle permission asking in ListExamplesActivity
+        }
+
         // do not show Google's outdoor location
         mMap.setMyLocationEnabled(false);
         mMap.setOnMapClickListener(this);

--- a/Basic/src/main/java/com/indooratlas/android/sdk/examples/wayfinding/WayfindingOverlayActivity.java
+++ b/Basic/src/main/java/com/indooratlas/android/sdk/examples/wayfinding/WayfindingOverlayActivity.java
@@ -1,12 +1,10 @@
 package com.indooratlas.android.sdk.examples.wayfinding;
 
-import android.Manifest;
-import android.content.pm.PackageManager;
+import android.annotation.SuppressLint;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.design.widget.Snackbar;
-import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.FragmentActivity;
 import android.util.Log;
 import android.view.View;
@@ -37,6 +35,7 @@ import com.indooratlas.android.sdk.IARegion;
 import com.indooratlas.android.sdk.IARoute;
 import com.indooratlas.android.sdk.IAWayfindingListener;
 import com.indooratlas.android.sdk.IAWayfindingRequest;
+import com.indooratlas.android.sdk.examples.ListExamplesActivity;
 import com.indooratlas.android.sdk.examples.R;
 import com.indooratlas.android.sdk.examples.SdkExample;
 import com.indooratlas.android.sdk.resources.IAFloorPlan;
@@ -256,12 +255,14 @@ public class WayfindingOverlayActivity extends FragmentActivity
         }
     }
 
+    @SuppressLint("MissingPermission")
     @Override
     public void onMapReady(GoogleMap googleMap) {
         mMap = googleMap;
 
-        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+        if (!ListExamplesActivity.checkLocationPermissions(this)) {
             finish(); // Handle permission asking in ListExamplesActivity
+            return;
         }
 
         // do not show Google's outdoor location

--- a/Basic/src/main/res/values/strings.xml
+++ b/Basic/src/main/res/values/strings.xml
@@ -13,8 +13,8 @@
     <string name="example_googlemaps_indoor_title">Google Indoor Maps</string>
     <string name="example_googlemaps_indoor_description">Demonstrates using IndoorAtlas locations on Google Indoor Maps</string>
     <string name="location_permission_request_title">Permission required</string>
-    <string name="location_permission_request_rationale">Access to coarse location is required for faster first fix.</string>
-    <string name="location_permission_denied_message">No access to locations. Time to first fix may be severely delayed!</string>
+    <string name="location_permission_request_rationale">Access to coarse location is required for faster first fix and for some examples.</string>
+    <string name="location_permission_denied_message">No access to locations. Time to first fix may be severely delayed and some examples may not work!</string>
     <string name="storage_permission_denied_message">No access to external storage. Permission needed for displaying floor plans</string>
     <string name="button_ok">OK</string>
     <string name="button_cancel">Cancel</string>
@@ -25,7 +25,7 @@
     <string name="configuration_incomplete_message">API credentials needed, please see gradle.properties in project root level.</string>
     <string name="dialog_set_location_title">Set location</string>
     <string name="error_could_not_set_location">Error setting location: %s</string>
-    <string name="action_share">Share...</string>
+    <string name="action_share">Share…</string>
     <string name="share_dialog_title">Your shared name?</string>
     <string name="current_channel">Current channel: %s</string>
     <string name="error_loading_floor_plan">Error while loading floor plan</string>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.2'
     }
 }
 
@@ -18,13 +18,13 @@ allprojects {
         jcenter()
         mavenCentral()
         maven {
-            url "http://indooratlas-ltd.bintray.com/mvn-public"
+            url "https://indooratlas-ltd.bintray.com/mvn-public"
         }
         maven {
-            url "http://indooratlas-ltd.bintray.com/mvn-public-alpha"
+            url "https://indooratlas-ltd.bintray.com/mvn-public-alpha"
         }
         maven {
-            url "http://indooratlas-ltd.bintray.com/mvn-public-beta"
+            url "https://indooratlas-ltd.bintray.com/mvn-public-beta"
         }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Mar 08 16:02:34 EET 2019
+#Tue Oct 20 16:00:42 EEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
* Fixes the `java.lang.NoClassDefFoundError: Failed resolution of: Lorg/apache/http/ProtocolVersion` crashes introduced most likely by [this commit](https://github.com/IndoorAtlas/android-sdk-examples/pull/94/files) by updating the Google Map libraries. 
* Lib updates required some minor changes to related examples
  * Google Maps examples (Indoor-Outdoor & Geofences) needed explicit permission checking (failure delegated back to the example list)
  * ImageView example's permissions for internal storage needed fixing too